### PR TITLE
Adding MVP roles DTR-27 (#308)

### DIFF
--- a/mvproles.csv
+++ b/mvproles.csv
@@ -25,7 +25,7 @@ dtr,model,view,presenter[,tripco for the team of four]
 24,ColtonTapparo,PigmyPeople,hunterv
 25,,,
 26,,,
-27,,,
+27,arpellerito,dlennox24,gtjohnso
 28,,,
 29,,,
 30,kelseycribari,lsouth,ekdoan


### PR DESCRIPTION
Adding DTR-27's MVP roles to `mvproles.csv`

(closes #308)