### PR TITLE
Removed empty rx and ry attributes from background rect

### DIFF
--- a/sprint3/World2.svg
+++ b/sprint3/World2.svg
@@ -51,8 +51,6 @@
      style="fill-rule:nonzero;stroke:black;stroke-miterlimit:4"
      id="Background"
      transform="scale(1.279907,1.279907)"><rect
-       rx=""
-       ry=""
        y="0"
        x="0"
        height="400"


### PR DESCRIPTION
They were causing errors errors in come rendering tools and served no purpose for the map.