### PR TITLE
Removed rx and ry attributes from background rect

### DIFF
--- a/sprint3/World4.svg
+++ b/sprint3/World4.svg
@@ -357,8 +357,6 @@
   <rect
      class="sea"
      id="rect5538"
-     rx=""
-     ry=""
      y="0.023644973"
      x="0.45669788"
      height="400"


### PR DESCRIPTION
The empty (non-numeric) values caused errors with some rendering tools.   They were optional and not needed for our purposes.